### PR TITLE
feat(i18n): localize default journal title and extract from hardcoded values

### DIFF
--- a/common/src/main/java/com/evandev/fieldguide/client/progress/ProgressManager.java
+++ b/common/src/main/java/com/evandev/fieldguide/client/progress/ProgressManager.java
@@ -56,7 +56,7 @@ public class ProgressManager {
     private final List<JournalPage> journalPages = new ArrayList<>();
     private String lastUnlockedVariant = null;
 
-    private String journalTitle = "My Field Guide";
+    private String journalTitle = null;
 
     private long lastUnlockTime = 0;
     private Object lastUnlockedEntry = null;
@@ -172,7 +172,13 @@ public class ProgressManager {
             entryTriggers.putAll(packet.getEntryTriggers());
         }
 
-        packet.getJournalTitle().ifPresent(title -> journalTitle = title);
+        packet.getJournalTitle().ifPresent(title -> {
+            if (title != null && !title.isEmpty()) {
+                journalTitle = title;
+            } else {
+                journalTitle = null;
+            }
+        });
         packet.getJournalPages().ifPresent(pages -> {
             journalPages.clear();
             for (PlayerFieldGuideProgress.JournalPageData page : pages) {
@@ -371,11 +377,18 @@ public class ProgressManager {
     }
 
     public String getJournalTitle() {
-        return journalTitle;
+        if (journalTitle != null && !journalTitle.isEmpty()) {
+            return journalTitle;
+        }
+        return I18n.get("fieldguide.journal.default.title");
     }
 
     public void setJournalTitle(String title) {
-        this.journalTitle = title;
+        if (title == null || title.trim().isEmpty()) {
+            this.journalTitle = null;
+        } else {
+            this.journalTitle = title;
+        }
         sendJournalUpdate();
     }
 
@@ -398,7 +411,7 @@ public class ProgressManager {
             JournalPage page = journalPages.get(i);
             pageData.add(new PlayerFieldGuideProgress.JournalPageData(page.title, page.content, page.timestamp));
         }
-        Services.NETWORK.sendToServer(new UpdateJournalPacket(journalTitle, pageData));
+        Services.NETWORK.sendToServer(new UpdateJournalPacket(journalTitle != null ? journalTitle : "", pageData));
     }
 
     public void onWorldLoad() {
@@ -412,7 +425,7 @@ public class ProgressManager {
         selectedVariants.clear();
         entryTriggers.clear();
         journalPages.clear();
-        journalTitle = "My Field Guide";
+        journalTitle = null;
         lastUnlockTime = 0;
         lastUnlockedEntry = null;
         lastUnlockedVariant = null;
@@ -429,7 +442,7 @@ public class ProgressManager {
         selectedVariants.clear();
         entryTriggers.clear();
         journalPages.clear();
-        journalTitle = "My Field Guide";
+        journalTitle = null;
         lastUnlockTime = 0;
         lastUnlockedEntry = null;
         lastUnlockedVariant = null;

--- a/common/src/main/java/com/evandev/fieldguide/server/progress/PlayerFieldGuideProgress.java
+++ b/common/src/main/java/com/evandev/fieldguide/server/progress/PlayerFieldGuideProgress.java
@@ -41,7 +41,7 @@ public class PlayerFieldGuideProgress {
     private final Set<String> pendingEntryResync = new LinkedHashSet<>();
     private boolean pendingFullSync = false;
 
-    private String journalTitle = "My Field Guide";
+    private String journalTitle = null;
     private boolean dirty = false;
 
     public PlayerFieldGuideProgress(UUID playerUUID, Path progressDir) {
@@ -297,7 +297,11 @@ public class PlayerFieldGuideProgress {
     }
 
     public void setJournalTitle(String title) {
-        this.journalTitle = title != null ? title : "My Field Guide";
+        if (title == null || title.trim().isEmpty()) {
+            this.journalTitle = null;
+        } else {
+            this.journalTitle = title;
+        }
         dirty = true;
     }
 
@@ -410,13 +414,12 @@ public class PlayerFieldGuideProgress {
         }
 
         Services.NETWORK.sendToPlayer(
-                new ProgressUpdatePacket.Builder()
-                        .silent(true)
-                        .journalTitle(journalTitle)
-                        .journalPages(new ArrayList<>(journalPages))
-                        .build(),
-                player
-        );
+            new ProgressUpdatePacket.Builder()
+                .silent(true)
+                .journalTitle(journalTitle != null ? journalTitle : "")
+                .journalPages(new ArrayList<>(journalPages))
+                .build(),
+            player);
     }
 
     private void sendDelta(ServerPlayer player) {
@@ -514,7 +517,13 @@ public class PlayerFieldGuideProgress {
                 );
             }
             if (json.has("journalTitle")) {
-                journalTitle = json.get("journalTitle").getAsString();
+                String loaded = json.get("journalTitle").getAsString();
+                // Migrate old default title to null if it's still present in the save file
+                if (!loaded.isEmpty() && !loaded.equals("My Field Guide")) {
+                    journalTitle = loaded;
+                } else {
+                    journalTitle = null;
+                }
             }
             if (json.has("journalPages")) {
                 journalPages.clear();
@@ -573,7 +582,9 @@ public class PlayerFieldGuideProgress {
             selectedVariants.forEach(variantsObj::addProperty);
             json.add("selectedVariants", variantsObj);
 
-            json.addProperty("journalTitle", journalTitle);
+            if (journalTitle != null) {
+                json.addProperty("journalTitle", journalTitle);
+            }
 
             JsonArray jpArr = new JsonArray();
             for (JournalPageData jp : journalPages) {

--- a/common/src/main/resources/assets/fieldguide/lang/en_us.json
+++ b/common/src/main/resources/assets/fieldguide/lang/en_us.json
@@ -385,5 +385,6 @@
   "advancements.fieldguide.quick_review.title": "I Don't Want to Play with You",
   "advancements.fieldguide.quick_review.description": "Scan a mob and then immediately kill it",
 
+  "fieldguide.journal.default.title": "My Field Guide",
   "fieldguide.journal.default": ""
 }

--- a/common/src/main/resources/assets/fieldguide/lang/es_ar.json
+++ b/common/src/main/resources/assets/fieldguide/lang/es_ar.json
@@ -157,5 +157,6 @@
   "fieldguide.name.fieldguide.huge_red_mushroom": "Champiñón Rojo Gigante",
   "fieldguide.name.fieldguide.huge_crimson_fungus": "Hongo Carmesí Gigante",
   "fieldguide.name.fieldguide.huge_warped_fungus": "Hongo Distorsionado Gigante",
+  "fieldguide.journal.default.title": "Mi Guía de Campo",
   "fieldguide.journal.default": ""
 }

--- a/common/src/main/resources/assets/fieldguide/lang/es_cl.json
+++ b/common/src/main/resources/assets/fieldguide/lang/es_cl.json
@@ -157,5 +157,6 @@
   "fieldguide.name.fieldguide.huge_red_mushroom": "Champiñón Rojo Gigante",
   "fieldguide.name.fieldguide.huge_crimson_fungus": "Hongo Carmesí Gigante",
   "fieldguide.name.fieldguide.huge_warped_fungus": "Hongo Distorsionado Gigante",
+  "fieldguide.journal.default.title": "Mi Guía de Campo",
   "fieldguide.journal.default": ""
 }

--- a/common/src/main/resources/assets/fieldguide/lang/es_ec.json
+++ b/common/src/main/resources/assets/fieldguide/lang/es_ec.json
@@ -157,5 +157,6 @@
   "fieldguide.name.fieldguide.huge_red_mushroom": "Champiñón Rojo Gigante",
   "fieldguide.name.fieldguide.huge_crimson_fungus": "Hongo Carmesí Gigante",
   "fieldguide.name.fieldguide.huge_warped_fungus": "Hongo Distorsionado Gigante",
+  "fieldguide.journal.default.title": "Mi Guía de Campo",
   "fieldguide.journal.default": ""
 }

--- a/common/src/main/resources/assets/fieldguide/lang/es_es.json
+++ b/common/src/main/resources/assets/fieldguide/lang/es_es.json
@@ -157,5 +157,6 @@
   "fieldguide.name.fieldguide.huge_red_mushroom": "Champiñón Rojo Gigante",
   "fieldguide.name.fieldguide.huge_crimson_fungus": "Hongo Carmesí Gigante",
   "fieldguide.name.fieldguide.huge_warped_fungus": "Hongo Distorsionado Gigante",
+  "fieldguide.journal.default.title": "Mi Guía de Campo",
   "fieldguide.journal.default": ""
 }

--- a/common/src/main/resources/assets/fieldguide/lang/es_mx.json
+++ b/common/src/main/resources/assets/fieldguide/lang/es_mx.json
@@ -157,5 +157,6 @@
   "fieldguide.name.fieldguide.huge_red_mushroom": "Champiñón Rojo Gigante",
   "fieldguide.name.fieldguide.huge_crimson_fungus": "Hongo Carmesí Gigante",
   "fieldguide.name.fieldguide.huge_warped_fungus": "Hongo Distorsionado Gigante",
+  "fieldguide.journal.default.title": "Mi Guía de Campo",
   "fieldguide.journal.default": ""
 }

--- a/common/src/main/resources/assets/fieldguide/lang/es_uy.json
+++ b/common/src/main/resources/assets/fieldguide/lang/es_uy.json
@@ -157,5 +157,6 @@
   "fieldguide.name.fieldguide.huge_red_mushroom": "Champiñón Rojo Gigante",
   "fieldguide.name.fieldguide.huge_crimson_fungus": "Hongo Carmesí Gigante",
   "fieldguide.name.fieldguide.huge_warped_fungus": "Hongo Distorsionado Gigante",
+  "fieldguide.journal.default.title": "Mi Guía de Campo",
   "fieldguide.journal.default": ""
 }

--- a/common/src/main/resources/assets/fieldguide/lang/es_ve.json
+++ b/common/src/main/resources/assets/fieldguide/lang/es_ve.json
@@ -157,5 +157,6 @@
   "fieldguide.name.fieldguide.huge_red_mushroom": "Champiñón Rojo Gigante",
   "fieldguide.name.fieldguide.huge_crimson_fungus": "Hongo Carmesí Gigante",
   "fieldguide.name.fieldguide.huge_warped_fungus": "Hongo Distorsionado Gigante",
+  "fieldguide.journal.default.title": "Mi Guía de Campo",
   "fieldguide.journal.default": ""
 }

--- a/common/src/main/resources/assets/fieldguide/lang/fr_fr.json
+++ b/common/src/main/resources/assets/fieldguide/lang/fr_fr.json
@@ -214,5 +214,6 @@
   "fieldguide.name.fieldguide.huge_crimson_fungus": "Verrue Carmine Géante",
   "fieldguide.name.fieldguide.huge_warped_fungus": "Verrue Biscornue Géante",
 
+  "fieldguide.journal.default.title": "Mon Guide",
   "fieldguide.journal.default": ""
 }

--- a/common/src/main/resources/assets/fieldguide/lang/ru_ru.json
+++ b/common/src/main/resources/assets/fieldguide/lang/ru_ru.json
@@ -385,5 +385,6 @@
   "advancements.fieldguide.quick_review.title": "Я больше не хочу с тобой играть",
   "advancements.fieldguide.quick_review.description": "Изучи существо, а затем тут же отправь его в мир иной",
 
+  "fieldguide.journal.default.title": "Мой дневник",
   "fieldguide.journal.default": ""
 }

--- a/common/src/main/resources/assets/fieldguide/lang/zh_cn.json
+++ b/common/src/main/resources/assets/fieldguide/lang/zh_cn.json
@@ -157,5 +157,6 @@
   "fieldguide.name.fieldguide.huge_red_mushroom": "红色巨型蘑菇",
   "fieldguide.name.fieldguide.huge_crimson_fungus": "巨型绯红菌",
   "fieldguide.name.fieldguide.huge_warped_fungus": "巨型诡异菌",
+  "fieldguide.journal.default.title": "我的生物百科图鉴",
   "fieldguide.journal.default": ""
 }

--- a/common/src/main/resources/assets/fieldguide/lang/zh_tw.json
+++ b/common/src/main/resources/assets/fieldguide/lang/zh_tw.json
@@ -157,5 +157,6 @@
   "fieldguide.name.fieldguide.huge_red_mushroom": "巨大紅色蘑菇",
   "fieldguide.name.fieldguide.huge_crimson_fungus": "巨大緋紅蕈",
   "fieldguide.name.fieldguide.huge_warped_fungus": "巨大扭曲蕈",
+  "fieldguide.journal.default.title": "我的生物百科圖鑑",
   "fieldguide.journal.default": ""
 }


### PR DESCRIPTION
### Preview
[<img alt="Medal" width="200" height="48" decoding="async" data-nimg="1" style="color: transparent; --darkreader-inline-color: transparent;" src="https://cdn.medal.tv/assets/next/img/medal-logo/logo-with-text-horizontal.93342752.webp" data-darkreader-inline-color="">](https://medal.tv/games/minecraft/clips/nd9wgm9wLidzUCncf?invite=cr-MSxUSnksNjAwNDQyNTcw)

### Context
The default journal title `"My Field Guide"` was hardcoded in the Java code. This meant players with non-English clients still saw the English title. This PR moves the default text into the translation system so it respects the player's language.

### Summary of Changes
- Replaced hardcoded `"My Field Guide"` with a translatable lang key `fieldguide.journal.default.title`.
- Changed the internal default from the hardcoded string to `null`. When no custom title is set, the game now pulls the text from the client's current language file.
- Empty or blank titles are treated as `null`, so they correctly fall back to the translated default instead of saving an invisible custom name.
- Added the translation key to all existing lang files.
- Old save files that still contain the literal text `"My Field Guide"` are automatically converted to `null` on load, so they pick up the new translated default immediately.

### Impact
- **Saves:** Fully backwards compatible. Existing worlds auto-migrate the old hardcoded title on next load.
- **UI/Localization:** The journal now shows the default title in the player's selected language.
- **Multiplayer:** No breaking changes. Empty strings are sent over the network when the title is unset, which the client resolves to the local translation.