### PR TITLE
Fix GeckoLib on 26.1

### DIFF
--- a/common/src/main/java/com/evandev/fieldguide/client/gui/util/EntryRenderHelper.java
+++ b/common/src/main/java/com/evandev/fieldguide/client/gui/util/EntryRenderHelper.java
@@ -35,6 +35,7 @@ import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.ARGB;
+import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
@@ -232,8 +233,8 @@ public class EntryRenderHelper {
             EntityRenderDispatcher dispatcher = Minecraft.getInstance().getEntityRenderDispatcher();
             EntityRenderer<T, S> renderer = (EntityRenderer<T, S>) dispatcher.getRenderer(entity);
 
-            S state = renderer.createRenderState();
-            renderer.extractRenderState(entity, state, 0.0F);
+            S state = renderer.createRenderState(entity, 0.0F);
+            state.lightCoords = LightCoordsUtil.FULL_BRIGHT;
 
             if (provider != null && variantDef != null && entity instanceof Mob mob) {
                 provider.applyToRenderState(mob, state, variantDef);

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ neo_form_version=26.1-1
 cloth_config_version=26.1.154
 mod_menu_version=18.0.0-alpha.8
 rrv_version=8.0.0+26.1.2
-item_descriptions_version=2.7.3+26.1.1
+item_descriptions_version=2.8.3+26.1.2
 immersive_overlays_version=1.6.4+26.1.1
 spyglass_improvements_version=1.5.7+mc26.1
 reliable_remover_version=2.0.3-26.1.2
@@ -33,7 +33,7 @@ fabric_version=0.146.1+26.1.2
 fabric_loader_version=0.19.0
 
 # NeoForge
-neoforge_version=26.1.1.4-beta
+neoforge_version=26.1.2.95
 neoforge_loader_version_range=[4,)
 
 # Gradle


### PR DESCRIPTION
Geckolib causes `createRenderState` to be `null` unless an entity is provided. This fixes the issue by using the overload that Geckolib does not break, and corrects the lighting on the entity as well since this method tries to apply vanilla lighting effects (also only affects Geckolib entities, but has no negative effects on vanilla ones).

NeoForge version was bumped to latest stable to test GeckoLib correctly.

Tested with [Untitled Duck Mod](https://modrinth.com/mod/untitled-duck-mod) and [Critters and Companions](https://modrinth.com/mod/critters-and-companions-(unofficial-fabric-port)).